### PR TITLE
Security fixes + session gem replacement

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,0 +1,4 @@
+## 0.4
+
+  * fixed Open3 usage, support for Ruby 1.9
+

--- a/devise_unix2_chkpwd_authenticatable.gemspec
+++ b/devise_unix2_chkpwd_authenticatable.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'devise_unix2_chkpwd_authenticatable'
-  s.version = "0.3"
+  s.version = "0.4"
   s.authors = ['Vladislav Lewin']
   s.date = '2011-02-01'
   s.description = 'For authenticating against PAM (Pluggable Authentication Modules)'

--- a/devise_unix2_chkpwd_authenticatable.gemspec
+++ b/devise_unix2_chkpwd_authenticatable.gemspec
@@ -28,7 +28,6 @@ Gem::Specification.new do |s|
   s.summary = 'Devise PAM authentication module using unix2_chkpwd'
 
   s.add_runtime_dependency('devise', ["> 1.1.0"])
-  s.add_runtime_dependency('session', ["> 2.4.0"])
 
 end
 

--- a/devise_unix2_chkpwd_authenticatable.gemspec
+++ b/devise_unix2_chkpwd_authenticatable.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'devise_unix2_chkpwd_authenticatable'
-  s.version = "0.2"
+  s.version = "0.3"
   s.authors = ['Vladislav Lewin']
   s.date = '2011-02-01'
   s.description = 'For authenticating against PAM (Pluggable Authentication Modules)'

--- a/lib/devise_unix2_chkpwd_authenticatable/model.rb
+++ b/lib/devise_unix2_chkpwd_authenticatable/model.rb
@@ -20,7 +20,7 @@ module Devise
       def unix2_chkpwd(login, passwd)
         Rails.logger.info "*** UNIX2_CHKPWD: checking password for user #{login.inspect}"
         
-        cmd = "/sbin/unix2_chkpwd passwd '#{login}'"
+        cmd = "/sbin/unix2_chkpwd passwd '#{escape_quotes login}'"
         session = Session.new
         result, err = session.execute cmd, :stdin => passwd
         ret = session.get_status.zero?
@@ -28,6 +28,13 @@ module Devise
         ret
       end
 
+      private
+
+      def escape_quotes(cmd)
+        cmd.gsub /'/,"'\\\\''"
+      end
+
+      public
 
       module ClassMethods
     

--- a/lib/devise_unix2_chkpwd_authenticatable/model.rb
+++ b/lib/devise_unix2_chkpwd_authenticatable/model.rb
@@ -18,7 +18,7 @@ module Devise
       end
 
       def unix2_chkpwd(login, passwd)
-        Rails.logger.error "*** UNIX2_CHKPWD #{login.inspect}"
+        Rails.logger.info "*** UNIX2_CHKPWD: checking password for user #{login.inspect}"
         
         cmd = "/sbin/unix2_chkpwd passwd '#{login}'"
         session = Session.new
@@ -32,7 +32,7 @@ module Devise
       module ClassMethods
     
         def authenticate_with_unix2_chkpwd(attributes={})
-         Rails.logger.error "*** Authenticate with UNIX2_CHKPWD #{attributes.inspect}"
+         Rails.logger.debug "*** Authenticate with UNIX2_CHKPWD, username: #{attributes[:username].inspect}"
          return nil unless attributes[:username].present?
 
          resource = scoped.where(:username => attributes[:username]).first


### PR DESCRIPTION
Hi, this pull request contains several fixes:
- fixed shell command injection vulnerability: escape quotes in the input, user could run any arbitrary command and/or skip the password check. Example username: ' ; /bin/touch /tmp/hacked; echo '  (including the quotes)
- fixed logging: decreased log level, don't log user password
- get rid of session gem dependency (open3 is used) - for some reason Session.new failed with "Broken pipe" error when running webyast in nginx, but when running via "rails server" it was OK
  With open3 it works correctly in both scenarios, and the gem dependencies are decreased
