### PR TITLE
HTTP Basic authentication support + some fixes

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,8 @@
+## 0.4.1
+
+  * added HTTP Basic authentication support
+  * fixed logging
+
 ## 0.4
 
   * fixed Open3 usage, support for Ruby 1.9

--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,0 +1,20 @@
+Copyright 2011-2012 Duncan Mac-Vicar P
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/devise_unix2_chkpwd_authenticatable.gemspec
+++ b/devise_unix2_chkpwd_authenticatable.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'devise_unix2_chkpwd_authenticatable'
-  s.version = "0.4"
+  s.version = "0.4.1"
   s.authors = ['Vladislav Lewin']
   s.date = '2011-02-01'
   s.description = 'For authenticating against PAM (Pluggable Authentication Modules)'

--- a/lib/devise_unix2_chkpwd_authenticatable/model.rb
+++ b/lib/devise_unix2_chkpwd_authenticatable/model.rb
@@ -30,7 +30,7 @@ module Devise
             stdin.write passwd
             stdin.close
             error = stderr.read
-            Rails.logger.error "*** UNIX2_CHKPWD: Password check failed: #{error}" if error
+            Rails.logger.error "*** UNIX2_CHKPWD: Password check failed: #{error}" unless error.empty?
             success = stdout.read == "0\n"
          end
         else
@@ -39,7 +39,7 @@ module Devise
             stdin.write passwd
             stdin.close
             error = stderr.read
-            Rails.logger.error "*** UNIX2_CHKPWD: Password check failed: #{error}" if error
+            Rails.logger.error "*** UNIX2_CHKPWD: Password check failed: #{error}" unless error.empty?
             success = wait_thr.value.exitstatus == 0
           end
         end

--- a/lib/devise_unix2_chkpwd_authenticatable/strategy.rb
+++ b/lib/devise_unix2_chkpwd_authenticatable/strategy.rb
@@ -5,13 +5,23 @@ module Devise
     class Unix2ChkpwdAuthenticatable < Base
 
       def valid?
-        valid = valid_params? && mapping.to.respond_to?(:authenticate_with_unix2_chkpwd)
+        valid = (valid_params? || valid_http_auth?) && mapping.to.respond_to?(:authenticate_with_unix2_chkpwd)
         Rails.logger.debug "valid?: #{valid}"
         valid
       end
 
       def authenticate!
-        if resource = mapping.to.authenticate_with_unix2_chkpwd(params[scope])
+        credentials = params[scope]
+
+        # credentials are empty when using HTTP auth
+        if credentials.nil?
+          # only HTTP Basic authentication is supported
+          request.authorization =~ /^Basic (.*)/m
+          usrname, pwd = Base64.decode64($1).split(/:/, 2)
+          credentials = {:username => usrname, :password => pwd}
+        end
+
+        if resource = mapping.to.authenticate_with_unix2_chkpwd(credentials)
           Rails.logger.error "*** Success!"
           success!(resource)
         else
@@ -30,6 +40,10 @@ module Devise
           params[scope] && params[scope][:password].present?
         end
 
+        def valid_http_auth?
+          # HTTP authentication enabled and credentials present in the request
+          mapping.to.http_authenticatable?(:unix2chkpwd) && request.authorization && request.authorization.match(/^Basic (.*)/)
+        end
     end
   end
 end

--- a/lib/devise_unix2_chkpwd_authenticatable/strategy.rb
+++ b/lib/devise_unix2_chkpwd_authenticatable/strategy.rb
@@ -22,7 +22,7 @@ module Devise
         end
 
         if resource = mapping.to.authenticate_with_unix2_chkpwd(credentials)
-          Rails.logger.error "*** Success!"
+          Rails.logger.info "*** Success!"
           success!(resource)
         else
           Rails.logger.error "*** Invalid!"


### PR DESCRIPTION
Hi,

I added HTTP Basic authentication support which is needed for WebYaST REST API. Users can simply use "curl -u <username>:<password>" instead of sending login form via POST request and using the returned cookie.

There are also some logging fixes, increased version and added MIT-LICENSE file to explicitly set the library license.
