### PR TITLE
Do not log authentication token sent via HTTP Basic Authentication

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,7 @@
+## 0.4.2
+
+  * do not log authentication token passed via user name in HTTP Basic authentication
+
 ## 0.4.1
 
   * added HTTP Basic authentication support

--- a/devise_unix2_chkpwd_authenticatable.gemspec
+++ b/devise_unix2_chkpwd_authenticatable.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |s|
   s.name = 'devise_unix2_chkpwd_authenticatable'
-  s.version = "0.4.1"
+  s.version = "0.4.2"
   s.authors = ['Vladislav Lewin']
   s.date = '2011-02-01'
   s.description = 'For authenticating against PAM (Pluggable Authentication Modules)'

--- a/lib/devise_unix2_chkpwd_authenticatable/model.rb
+++ b/lib/devise_unix2_chkpwd_authenticatable/model.rb
@@ -18,7 +18,10 @@ module Devise
       end
 
       def unix2_chkpwd(login, passwd)
-        Rails.logger.info "*** UNIX2_CHKPWD: checking password for user #{login.inspect}"
+        # do not log authentication token when sent via HTTP Basic auth as user name
+        # see https://github.com/plataformatec/devise/blob/master/lib/devise/strategies/token_authenticatable.rb#L10
+        log_name = login && login.size == 20 && (passwd == "" || passwd == "X") ? "[FILTERED]" : login
+        Rails.logger.info "*** UNIX2_CHKPWD: checking password for user #{log_name.inspect}"
 
         success = nil
 


### PR DESCRIPTION
A token created by :token_authenticatable module can be sent also via HTTP Basic Authentication as user name, in that case it must not be logged (an attacker could read the token from log and compromise the system)

Version 0.4.2

(See https://bugzilla.novell.com/show_bug.cgi?id=781128#c2)
